### PR TITLE
Allow for arbitrary `kwargs` in `tree(...)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,36 @@ julia> PkgDependency.tree("CSV")
       └── SentinelArrays v1.3.13
 ```
 
+If you want to customize the display of the tree, you can pass extra keyword arguments
+to `PkgDependency.tree`. These will be passed on to the `Term.Trees.Tree` constructor
+and subsequently, the `AbstractTrees.print_tree` method. For example:
+
+```console
+julia> using PkgDependency
+julia> PkgDependency.tree("CSV", maxdepth=1)
+CSV 0.10.4                
+  ├─ InlineStrings v1.4.0 
+  │  ⋮                    
+  │                       
+  ├─ PooledArrays v1.4.3  
+  │  ⋮                    
+  │                       
+  ├─ WeakRefStrings v1.4.2
+  │  ⋮                    
+  │                       
+  ├─ CodecZlib v0.7.4     
+  │  ⋮                    
+  │                       
+  ├─ Tables v1.11.1       
+  │  ⋮                    
+  │                       
+  ├─ FilePathsBase v0.9.21
+  │  ⋮                    
+  │                       
+  ├─ Parsers v2.8.1 (*)   
+  └─ SentinelArrays v1.4.1
+```
+
 ## Contribution
 
 Feel free to create issues if you want more features!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,6 +27,7 @@ Unless otherwise specified, all methods of `tree` function support following kwa
 | `show_link` | `false` | show packages' repo link in tree |
 | `dedup` | `true` | hide duplicate dependencies in tree |
 | `stdlib` | `false` | show packages from Standard Library |
+| ... | | Any kwargs supported by [`Term.Trees.Tree`](https://fedeclaudi.github.io/Term.jl/stable/api/api_trees/#Term.Trees.Tree) and `AbstractTrees.print_tree`. |
 
 ## API
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,14 +6,16 @@ import Term: Tree
     for dedup in [true; false]
     for compat in [true; false]
     for stdlib in [true; false]
-        @test PkgDependency.tree(; compat, dedup, stdlib) isa Tree
-        @test PkgDependency.tree("Term"; compat, dedup, stdlib) isa Tree
-        @test PkgDependency.tree("Term"; reverse=true, compat, dedup, stdlib) isa Tree
+    for maxdepth in [99; 1; 2]
+        @test PkgDependency.tree(; compat, dedup, stdlib, maxdepth) isa Tree
+        @test PkgDependency.tree("Term"; compat, dedup, stdlib, maxdepth) isa Tree
+        @test PkgDependency.tree("Term"; reverse=true, compat, dedup, stdlib, maxdepth) isa Tree
         if VERSION < v"1.7"
-            @test_throws ErrorException PkgDependency.tree("Term"; compat, show_link=true, dedup, stdlib) isa Tree
+            @test_throws ErrorException PkgDependency.tree("Term"; compat, show_link=true, dedup, stdlib, maxdepth) isa Tree
         else
-            @test PkgDependency.tree("Term"; compat, show_link=true, dedup, stdlib) isa Tree
+            @test PkgDependency.tree("Term"; compat, show_link=true, dedup, stdlib, maxdepth) isa Tree
         end
+    end
     end
     end
     end


### PR DESCRIPTION
This change allows for users to control features like the `maxdepth` of the tree. It is also a more robust solution than, for example, simply adding a `maxdepth` argument to `tree(...)` itself.

Without `maxdepth`:

<details><summary>Output</summary>
<p>

```julia
julia> PkgDependency.tree("Term")
Term 2.0.6                                       
  ├─ ProgressLogging v0.1.4                      
  │  └─ SHA v0.7.0                               
  ├─ CodeTracking v1.3.5                         
  ├─ PrecompileTools v1.2.1                      
  │  └─ Preferences v1.4.3                       
  │     └─ TOML v1.0.3                           
  ├─ OrderedCollections v1.6.3                   
  ├─ MyterialColors v0.3.0                       
  ├─ Tables v1.11.1                              
  │  ├─ DataAPI v1.16.0                          
  │  ├─ OrderedCollections v1.6.3 (*)            
  │  ├─ IteratorInterfaceExtensions v1.0.0       
  │  ├─ DataValueInterfaces v1.0.0               
  │  └─ TableTraits v1.0.1                       
  │     └─ IteratorInterfaceExtensions v1.0.0 (*)
  ├─ UnicodeFun v0.4.1                           
  ├─ AbstractTrees v0.4.5                        
  ├─ Parameters v0.12.3                          
  │  ├─ OrderedCollections v1.6.3 (*)            
  │  └─ UnPack v1.0.2                            
  └─ Highlights v0.5.2                           
     └─ DocStringExtensions v0.9.3
```

</p>
</details> 

With `maxdepth=1`, for example:

<details><summary>Output</summary>
<p>

```julia
PkgDependency.tree("Term", maxdepth=1)
Term 2.0.6                    
  ├─ ProgressLogging v0.1.4   
  │  ⋮                        
  │                           
  ├─ CodeTracking v1.3.5      
  ├─ PrecompileTools v1.2.1   
  │  ⋮                        
  │                           
  ├─ OrderedCollections v1.6.3
  ├─ MyterialColors v0.3.0    
  ├─ Tables v1.11.1           
  │  ⋮                        
  │                           
  ├─ UnicodeFun v0.4.1        
  ├─ AbstractTrees v0.4.5     
  ├─ Parameters v0.12.3       
  │  ⋮                        
  │                           
  └─ Highlights v0.5.2        
     ⋮                        
```

</p>
</details>

I've added tests for the `maxdepth` keyword and updated the documentation to highlight the added functionality. The `print_tree` documentation is currently not published, so I've omitted that link (waiting on https://github.com/JuliaCollections/AbstractTrees.jl/pull/145). 